### PR TITLE
Disable soft error limit

### DIFF
--- a/src/pytest_mypy_testing/plugin.py
+++ b/src/pytest_mypy_testing/plugin.py
@@ -150,6 +150,7 @@ class PytestMypyFile(pytest.File):
                 "--no-color-output",
                 "--no-error-summary",
                 "--no-pretty",
+                "--soft-error-limit=-1",
                 "--no-silence-site-packages",
                 "--no-warn-unused-configs",
                 "--show-column-numbers",


### PR DESCRIPTION
Especially with `--no-silence-site-packages` newer versions of mypy can produce a number of errors that's over the [soft error limit](https://mypy.readthedocs.io/en/stable/command_line.html?highlight=200#cmdoption-mypy-soft-error-limit) which defaults to 200. By setting it to -1, we disable it, which makes sense for something as predictable as a diff of expected vs. actual errors.

(Not sure why we have `--no-silence-site-packages` in the arguments, but that's a separate question.)