### PR TITLE
Allow Windows drives in filename

### DIFF
--- a/src/pytest_mypy_testing/message.py
+++ b/src/pytest_mypy_testing/message.py
@@ -74,7 +74,7 @@ class Message:
     )
 
     OUTPUT_RE = re.compile(
-        r"^(?P<fname>[^:]+):"
+        r"^(?P<fname>([a-zA-Z]:)?[^:]+):"
         r"(?P<lineno>[0-9]+):"
         r"((?P<colno>[0-9]+):)?"
         r" *(?P<severity>(error|note|warning)):"


### PR DESCRIPTION
This allows the colon (:) in the drive specifier on Windows to be included into the fname match.

Fixes #17 