### PR TITLE
Proposal for supporting call-overload errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,17 @@ the file:
 * `# F: <msg>` - we expect a mypy fatal error message
 * `# R: <msg>` - we expect a mypy note message `Revealed type is
   '<msg>'`. This is useful to easily check `reveal_type` output:
+
      ```python
      @pytest.mark.mypy_testing
      def mypy_use_reveal_type():
          reveal_type(123)  # N: Revealed type is 'Literal[123]?'
          reveal_type(456)  # R: Literal[456]?
      ```
+
+* `# O: <msg>` - we expect a mypy error message and additionally suppress any
+  notes on the same line. This is useful to test for errors such as
+  `call-overload` where mypy provides extra details in notes along with the error.
 
 ## mypy Error Code Matching
 

--- a/src/pytest_mypy_testing/output_processing.py
+++ b/src/pytest_mypy_testing/output_processing.py
@@ -106,6 +106,17 @@ def diff_message_sequences(
 
     errors: List[OutputMismatch] = []
 
+    # If an expected message has specified to suppress notes on a line, then
+    # drop them before performing the comparison.
+    suppress_notes_lines = {
+        msg.lineno for msg in expected_messages if msg.suppress_notes
+    }
+    actual_messages = [
+        msg
+        for msg in actual_messages
+        if msg.lineno not in suppress_notes_lines or msg.severity != Severity.NOTE
+    ]
+
     for a_chunk, b_chunk in iter_msg_seq_diff_chunks(
         actual_messages, expected_messages
     ):

--- a/tests/test_basics.mypy-testing
+++ b/tests/test_basics.mypy-testing
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 import pytest
+import dataclasses
 
 
 @pytest.mark.mypy_testing
@@ -97,3 +98,11 @@ def mypy_test_xfail_missing_note():
 @pytest.mark.xfail
 def mypy_test_xfail_unexpected_note():
     reveal_type([])  # unexpected message
+
+
+@pytest.mark.mypy_testing
+def mypy_test_suppress_notes():
+    # Check the use of the "O" severity
+    dataclasses.field(default=123, default_factory=lambda: 456) # O: [call-overload]
+    # Check that notes on other lines are not suppressed
+    reveal_type(123) # N: Revealed type is 'Literal[123]?'


### PR DESCRIPTION
Proposed fix for #44 

Adds a new severity symbol "O" (i.e. call-Overload).
This new severity acts as "E" but activates suppression of note messages on the same line.
Documentation and testing updated to reflect this behaviour.

Hopefully this proposal is useful.
If there's a better design to help handle this case I'd be happy to help out with any alternative implementation suggestions!

