### PR TITLE
Target Python 3.9 when running tests

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: CC0-1.0
 [mypy]
 
-python_version = 3.8
+python_version = 3.9
 
 mypy_path = src
 


### PR DESCRIPTION
mypy 1.17.0 dropped support for targeting Python 3.8, causing https://bugs.debian.org/1114284.

I guess you might want to do something with the matrix in `tox.ini` as well, but I'm not sure how extensive you want that to be.